### PR TITLE
DL-3623 Business Type Match

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -7,8 +7,7 @@ object AppDependencies {
 
   val compile: Seq[ModuleID] = Seq(
     ws,
-    "uk.gov.hmrc" %% "bootstrap-play-26" % "1.7.0",
-    "uk.gov.hmrc" %% "domain" % "5.8.0-play-26"
+    "uk.gov.hmrc" %% "bootstrap-play-26" % "1.13.0"
   )
 
   def apply() = compile ++ Test()

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.10
+sbt.version=1.3.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,15 +2,15 @@ resolvers += Resolver.url("HMRC Sbt Plugin Releases", url("https://dl.bintray.co
 
 resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
 
-resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
+resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.6.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.9.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.0.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.2.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.3.0")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.25")
 

--- a/test/uk/gov/hmrc/services/SubscribeServiceSpec.scala
+++ b/test/uk/gov/hmrc/services/SubscribeServiceSpec.scala
@@ -83,6 +83,7 @@ class SubscribeServiceSpec extends PlaySpec with OneServerPerSuite with MockitoS
       |      "email": "aa@aa.com"
       |    }
       | }],
+      | "businessType": "Corporate Body",
       | "utr":"12345",
       | "isNonUKClientRegisteredByAgent": false,
       | "knownFactPostcode": "NE1 1EN"}
@@ -140,6 +141,7 @@ class SubscribeServiceSpec extends PlaySpec with OneServerPerSuite with MockitoS
         |      "email": "aa@aa.com"
         |    }
         | }],
+        |  "businessType": "LLP",
         |  "utr":"12345",
         |  "isNonUKClientRegisteredByAgent": false}
         |


### PR DESCRIPTION
DL-3623 Business Type Match

**Bug fix** 

ATED Subscription was incorrectly setting a known fact verifier to CTUTR for all users without checking on business-type first. For partnerships the business types verifier should be SAUTR. There is a PR for the Frontend which allows the business type to be passed in to the backend so the business type match could be implemented. (https://github.com/hmrc/ated-subscription-frontend/pull/115)

**NOTE: When running acceptance tests "ReviewBusinessDetails" test case fails 40% of the time, but passed 60% of the time. Not sure if my laptop is acting up or an implementation issue**

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
