### PR TITLE
Removed postcode space removal from ES6 call

### DIFF
--- a/app/services/EtmpRegimeService.scala
+++ b/app/services/EtmpRegimeService.scala
@@ -89,7 +89,7 @@ class EtmpRegimeService @Inject()(etmpConnector: EtmpConnector,
             case Some(_) =>
               upsertAtedKnownFacts(
                 bcd.utr,
-                bcd.businessAddress.postcode.map(_.replaceAll("\\s+", "")),
+                bcd.businessAddress.postcode,
                 etmpRegDetails.regimeRefNumber,
                 bcd.businessType,
               ) map { response =>


### PR DESCRIPTION
# Removed postcode space removal from ES6 call

**Bug fix**

* Removed postcode space removal from ES6 calls 

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
