### PR TITLE
DL-6550 plat28 upgrade plus dependencies and plugins

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ lazy val plugins: Seq[Plugins] = Seq(play.sbt.PlayScala, SbtDistributablesPlugin
     import scoverage.ScoverageKeys
     Seq(
       ScoverageKeys.coverageExcludedPackages := "<empty>;Reverse.*;app.Routes.*;prod.*;uk.gov.hmrc.*;testOnlyDoNotUseInAppConf.*;forms.*;config.*;",
-      ScoverageKeys.coverageMinimum := 95,
+      ScoverageKeys.coverageMinimumStmtTotal := 95,
       ScoverageKeys.coverageFailOnMinimum := true,
       ScoverageKeys.coverageHighlighting := true
     )
@@ -58,7 +58,7 @@ lazy val microservice = Project(appName, file("."))
     resolvers += Resolver.typesafeRepo("releases"),
     resolvers += Resolver.jcenterRepo
   )
-  .enablePlugins(SbtDistributablesPlugin, SbtAutoBuildPlugin, SbtGitVersioning)
+  .enablePlugins(SbtDistributablesPlugin)
   .disablePlugins(JUnitXmlReportPlugin)
 
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -32,9 +32,9 @@ play.application.loader = "uk.gov.hmrc.play.bootstrap.ApplicationLoader"
 # Primary entry point for all HTTP requests on Play applications
 play.http.requestHandler = "uk.gov.hmrc.play.bootstrap.http.RequestHandler"
 
-# Provides an implementation of AuditConnector. Use `uk.gov.hmrc.play.bootstrap.AuditModule` or create your own.
+# Provides an implementation of AuditConnector. Use `uk.gov.hmrc.play.audit.AuditModule` or create your own.
 # An audit connector must be provided.
-play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuditModule"
+play.modules.enabled += "uk.gov.hmrc.play.audit.AuditModule"
 
 # Provides an implementation of MetricsFilter. Use `uk.gov.hmrc.play.bootstrap.graphite.GraphiteMetricsModule` or create your own.
 # A metric filter must be provided

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -7,7 +7,7 @@ object AppDependencies {
 
   val compile: Seq[ModuleID] = Seq(
     ws,
-    "uk.gov.hmrc" %% "bootstrap-backend-play-27" % "5.2.0"
+    "uk.gov.hmrc" %% "bootstrap-backend-play-28" % "5.16.0"
   )
 
   def apply(): Seq[sbt.ModuleID] = compile ++ Test()
@@ -20,11 +20,14 @@ object AppDependencies {
   object Test {
     def apply(): Seq[sbt.ModuleID] = new TestDependencies {
       override lazy val test = Seq(
-        "org.scalatestplus.play" %% "scalatestplus-play" % "4.0.3" % scope,
-        "org.pegdown" % "pegdown" % "1.6.0" % scope,
-        "com.typesafe.play" %% "play-test" % PlayVersion.current % scope,
-        "org.mockito" % "mockito-core" % "3.10.0" % scope,
-        "com.github.tomakehurst" % "wiremock-jre8" % "2.23.2" % IntegrationTest withSources()
+        "org.scalatestplus.play"       %% "scalatestplus-play"   % "5.1.0"             % scope,
+        "org.pegdown"                  % "pegdown"               % "1.6.0"             % scope,
+        "com.typesafe.play"            %% "play-test"            % PlayVersion.current % scope,
+        "org.mockito"                  % "mockito-core"          % "4.0.0"             % scope,
+        "org.scalatestplus"            %% "mockito-3-12"         % "3.2.10.0"          % scope,
+        "com.vladsch.flexmark"         %  "flexmark-all"         %  "0.35.10"          % scope,
+        "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.12.5"            % scope,
+        "com.github.tomakehurst"       % "wiremock-jre8"         % "2.31.0"            % IntegrationTest withSources()
       )
     }.test
   }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,10 @@
 resolvers += "HMRC-open-artefacts-maven" at "https://open.artefacts.tax.service.gov.uk/maven2"
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.0.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.5.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.9")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.8")
 
-addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "1.6.1")
+addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "1.9.1")


### PR DESCRIPTION
# DL-6550
**Maintenance** 

Upgrade to play28
Update dependencies and plugins

Note - Specifically added dependency for jackson-module-scala however it is possible to not use this and downgrade wiremock-jre8 to version that has a compatible version

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
