### PR TITLE
DL 12743 - Allowing users to reclaim enrolment despite delegated enrolment existing

### DIFF
--- a/app/connectors/TaxEnrolmentsConnector.scala
+++ b/app/connectors/TaxEnrolmentsConnector.scala
@@ -91,7 +91,7 @@ trait TaxEnrolmentsConnector extends RawResponseReads with Auditable with Loggin
 
   def getATEDGroups(atedRef: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Either[Int, AtedUsers]] = {
 
-    val url = s"$enrolmentStoreProxyUrl/enrolment-store-proxy/enrolment-store/enrolments/HMRC-ATED-ORG~ATEDRefNumber~$atedRef/groups"
+    val url = s"$enrolmentStoreProxyUrl/enrolment-store-proxy/enrolment-store/enrolments/HMRC-ATED-ORG~ATEDRefNumber~$atedRef/groups?ignore-assignments=true"
     http.GET[HttpResponse](url, Seq.empty).map {
       response =>
         response.status match {

--- a/app/connectors/TaxEnrolmentsConnector.scala
+++ b/app/connectors/TaxEnrolmentsConnector.scala
@@ -89,9 +89,9 @@ trait TaxEnrolmentsConnector extends RawResponseReads with Auditable with Loggin
         "status" -> s"$status"))
   }
 
-  def getATEDUsers(atedRef: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Either[Int, AtedUsers]] = {
+  def getATEDGroups(atedRef: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Either[Int, AtedUsers]] = {
 
-    val url = s"$enrolmentStoreProxyUrl/enrolment-store-proxy/enrolment-store/enrolments/HMRC-ATED-ORG~ATEDRefNumber~$atedRef/users"
+    val url = s"$enrolmentStoreProxyUrl/enrolment-store-proxy/enrolment-store/enrolments/HMRC-ATED-ORG~ATEDRefNumber~$atedRef/groups"
     http.GET[HttpResponse](url, Seq.empty).map {
       response =>
         response.status match {

--- a/app/models/AtedUsers.scala
+++ b/app/models/AtedUsers.scala
@@ -18,7 +18,7 @@ package models
 
 import play.api.libs.json.{Json, OFormat}
 
-case class AtedUsers(principalUserIds: List[String], delegatedUserIds: List[String])
+case class AtedUsers(principalGroupIds: List[String], delegatedGroupIds: List[String])
 
 
 object AtedUsers {

--- a/app/services/EnrolmentService.scala
+++ b/app/services/EnrolmentService.scala
@@ -26,6 +26,6 @@ import scala.concurrent.{ExecutionContext, Future}
 class EnrolmentService @Inject()(enrolmentStoreConnector: TaxEnrolmentsConnector) {
 
   def atedUsers(atedRefNo: String)(implicit headerCarrier: HeaderCarrier, ec: ExecutionContext): Future[Either[Int, AtedUsers]] =
-    enrolmentStoreConnector.getATEDUsers(atedRefNo)
+    enrolmentStoreConnector.getATEDGroups(atedRefNo)
 
 }

--- a/test/uk/gov/hmrc/connectors/TaxEnrolmentsConnectorSpec.scala
+++ b/test/uk/gov/hmrc/connectors/TaxEnrolmentsConnectorSpec.scala
@@ -86,28 +86,28 @@ class TaxEnrolmentsConnectorSpec extends PlaySpec with GuiceOneServerPerSuite wi
       implicit val hc: HeaderCarrier = HeaderCarrier(sessionId = Some(SessionId(s"session-${UUID.randomUUID}")))
       val jsOnData: JsValue = Json.toJson(atedUsersList)
       when(mockHttp.GET[HttpResponse](any(),any(), any())(any(),any(), any())).thenReturn(Future.successful(HttpResponse(OK, jsOnData.toString())))
-      val result: Future[Either[Int, AtedUsers]] = connector.getATEDUsers("ATED-123")
+      val result: Future[Either[Int, AtedUsers]] = connector.getATEDGroups("ATED-123")
       await(result) must be(Right(atedUsersList))
     }
 
     "for successful set of Ated users, return 200 success with Nil Ated Users list" in new Setup {
       implicit val hc: HeaderCarrier = HeaderCarrier(sessionId = Some(SessionId(s"session-${UUID.randomUUID}")))
       when(mockHttp.GET[HttpResponse](any(),any(), any())(any(),any(), any())).thenReturn(Future.successful(HttpResponse(NO_CONTENT, "")))
-      val result: Future[Either[Int, AtedUsers]] = connector.getATEDUsers("ATED-123")
+      val result: Future[Either[Int, AtedUsers]] = connector.getATEDGroups("ATED-123")
       await(result) must be(Right(AtedUsers(Nil, Nil)))
     }
 
     "for BadRequest response from enrolments backend, return a Bad request response" in new Setup {
       implicit val hc: HeaderCarrier = HeaderCarrier(sessionId = Some(SessionId(s"session-${UUID.randomUUID}")))
       when(mockHttp.GET[HttpResponse](any(),any(), any())(any(),any(), any())).thenReturn(Future.successful(HttpResponse(BAD_REQUEST, "")))
-      val result: Future[Either[Int, AtedUsers]] = connector.getATEDUsers("ATED-123")
+      val result: Future[Either[Int, AtedUsers]] = connector.getATEDGroups("ATED-123")
       await(result) must be(Left(BAD_REQUEST))
     }
 
     "for any other exception response from enrolments backend, return the same back to the caller" in new Setup {
       implicit val hc: HeaderCarrier = HeaderCarrier(sessionId = Some(SessionId(s"session-${UUID.randomUUID}")))
       when(mockHttp.GET[HttpResponse](any(),any(), any())(any(),any(), any())).thenReturn(Future.successful(HttpResponse(NOT_FOUND, "")))
-      val result: Future[Either[Int, AtedUsers]] = connector.getATEDUsers("ATED-123")
+      val result: Future[Either[Int, AtedUsers]] = connector.getATEDGroups("ATED-123")
       await(result) must be(Left(NOT_FOUND))
     }
 


### PR DESCRIPTION
# DL 12743 - Allowing users to reclaim enrolment despite delegated enrolment existing

**Bug fix**

Linked to PR for frontend and ATs.

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
